### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,71 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [0.2.8] - 2022-09-06
+
+### Bug Fixes
+
+- *(C)* Use char instead of uint8_t in field names
+- *(query)* Fix websocket v2 float null
+- *(tmq)* Enable expriment snapshot by default
+- *(ws)* Fix data lost in large query set
+- *(ws)* Fix bigint/unsigned-bigint precision bug
+- *(ws)* Fix stmt null error when buffer is empty
+- *(ws)* Fix timing compatibility bug for v2
+- *(ws)* Fix stmt bind with non-null values coredump
+- *(ws)* Fix query errno when connection is not alive
+- *(ws)* Fix fetch block unexpect exit
+- *(ws)* Add ws-related error codes, fix version detection
+- *(ws)* Use ws_errno/errstr in ws_fetch_block
+- *(ws)* Not block on ws_get_server_info
+- *(ws-sys)* Fix ws_free_result with NULL- Fix unknown action 'close', use 'free_result'
+- Fix version action response error in websocket
+- Fix websocket stmt set json tags error
+- Topics table rename
+- Support . in database part
+- Remove unused log print
+- Fix derive error since rustc-1.65.0-nightly
+- Remove usless file
+- .github/workflows/build.yml branch
+- Fix duplicate defines when use with taos.h
+- Taos-ws-sys/examples/show-databases.c
+- Gcc 7 compile error
+- Fix column length calculation for v2 block
+
+
+### Documentation
+- Fix build error on docs.rs
+- Add example for bind and r2d2
+- Add README and query/tmq examples
+- Add license and refine readme
+
+
+### Enhancements
+
+- *(ws)* Feature gated ssl support for websocket
+
+### Features
+
+- *(libtaosws)* Add ws_get_server_info
+- *(ws)* Add ws_stop_query, support write raw block
+- *(ws)* Add ws_take_timing method for taosc cost
+- *(ws)* Add stmt API- Add main connector
+- Support python lib for websocket
+
+
+### Refactor
+
+- *(query)* New version of raw block
+- *(query)* Refactor query interface- Fix stmt bind with raw block error
+- Fix nchar/json error, refactor error handling
+- Merge with main branch
+- Use stable channel
+
+
+### Testing
+- Fix llvm-cov test error and report code coverage
+
+
 ## [0.2.7] - 2022-09-02
 
 ### Bug Fixes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 
 [package]
 name = "taos"
-version = "0.2.7"
+version = "0.2.8"
 categories = ["database", "api-bindings", "asynchronous"]
 edition = "2021"
 keywords = ["timeseries", "database", "tdengine", "taosdata", "connection"]
@@ -27,9 +27,9 @@ no-default-features = true
 [dependencies]
 anyhow = "1"
 async-trait = "0.1"
-taos-query = { path = "./taos-query", version = "0.2.5" }
+taos-query = { path = "./taos-query", version = "0.2.6" }
 taos-sys = { path = "./taos-sys", version = "0.2.2", optional = true }
-taos-ws = { path = "./taos-ws", version = "0.2.4", optional = true }
+taos-ws = { path = "./taos-ws", version = "0.2.5", optional = true }
 thiserror = "1"
 
 [dev-dependencies]

--- a/taos-error/CHANGELOG.md
+++ b/taos-error/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [0.2.7] - 2022-09-06
+
+### Bug Fixes
+
+- *(ws)* Fix stmt bind with non-null values coredump
+- *(ws)* Add ws-related error codes, fix version detection- Fix derive error since rustc-1.65.0-nightly
+- Fix column length calculation for v2 block
+
+
+### Features
+
+- *(libtaosws)* Add ws_get_server_info
+- *(ws)* Add ws_take_timing method for taosc cost
+
+### Refactor
+
+- *(query)* Refactor query interface- Fix nchar/json error, refactor error handling
+
+
+### Testing
+- Fix llvm-cov test error and report code coverage
+
+
 ## [0.2.6] - 2022-09-02
 
 ### Bug Fixes

--- a/taos-error/Cargo.toml
+++ b/taos-error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taos-error"
-version = "0.2.6"
+version = "0.2.7"
 edition = "2021"
 homepage = "https://github.com/taosdata/taos-connector-rust"
 documentation = "https://docs.rs/taos-query"

--- a/taos-macros/CHANGELOG.md
+++ b/taos-macros/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [0.2.8] - 2022-09-06
+
+### Features
+- Add main connector
+
+
 ## [0.2.7] - 2022-09-02
 
 ### Features

--- a/taos-macros/Cargo.toml
+++ b/taos-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taos-macros"
-version = "0.2.7"
+version = "0.2.8"
 edition = "2021"
 keywords = ["taos", "TDengine", "proc-macro"]
 license = "MIT OR Apache-2.0"

--- a/taos-query/CHANGELOG.md
+++ b/taos-query/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [0.2.6] - 2022-09-06
+
+### Bug Fixes
+
+- *(ws)* Fix data lost in large query set
+
 ## [0.2.5] - 2022-09-02
 
 ### Bug Fixes

--- a/taos-query/Cargo.toml
+++ b/taos-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taos-query"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 homepage = "https://github.com/taosdata/taos-connector-rust"
 documentation = "https://docs.rs/taos-query"

--- a/taos-ws/CHANGELOG.md
+++ b/taos-ws/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [0.2.5] - 2022-09-06
+
+### Bug Fixes
+
+- *(ws)* Fix data lost in large query set- Fix unknown action 'close', use 'free_result'
+
+
 ## [0.2.4] - 2022-09-02
 
 ### Bug Fixes

--- a/taos-ws/Cargo.toml
+++ b/taos-ws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taos-ws"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 keywords = ["taos", "TDengine", "timeseries", "database"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `taos-error` -> 0.2.7
* `taos-query` -> 0.2.6
* `taos-macros` -> 0.2.8
* `taos-ws` -> 0.2.5
* `taos` -> 0.2.8
---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).