### PR TITLE
feat!: add MetaData variant for tmq message.

### DIFF
--- a/taos-sys/src/query/raw_res.rs
+++ b/taos-sys/src/query/raw_res.rs
@@ -214,7 +214,7 @@ impl RawRes {
                         raw.with_field_names(self.fetch_fields().iter().map(Field::name));
                         Some(raw)
                     }
-                    tmq_res_t::TMQ_RES_DATA => {
+                    tmq_res_t::TMQ_RES_DATA | tmq_res_t::TMQ_RES_METADATA => {
                         let fields = self.fetch_fields();
 
                         let mut raw = RawBlock::parse_from_ptr(block as _, self.precision());

--- a/taos-sys/src/tmq/ffi.rs
+++ b/taos-sys/src/tmq/ffi.rs
@@ -74,6 +74,7 @@ pub enum tmq_res_t {
     TMQ_RES_INVALID = -1,
     TMQ_RES_DATA = 1,
     TMQ_RES_TABLE_META = 2,
+    TMQ_RES_METADATA = 3,
 }
 
 // #[repr(C)]

--- a/taos-ws/src/consumer/mod.rs
+++ b/taos-ws/src/consumer/mod.rs
@@ -840,6 +840,7 @@ mod tests {
                 //
                 // 1. meta
                 // 2. data
+                // 3. meta + data
                 match message {
                     MessageSet::Meta(meta) => {
                         let _raw = meta.as_raw_meta().await?;
@@ -872,6 +873,7 @@ mod tests {
                             dbg!(data);
                         }
                     }
+                    _ => unreachable!()
                 }
                 consumer.commit(offset).await?;
             }
@@ -1021,6 +1023,7 @@ mod tests {
                         dbg!(block);
                     }
                 }
+                _ => unreachable!()
             }
             consumer.commit(offset)?;
         }


### PR DESCRIPTION
BREAKING CHANGE: MessageSet enum updated:

Previous:

```rust
match message {
    MessageSet::Meta(meta) => ...,
    MessageSet::Data(data) => ...,
}
```

Now:

```rust
match message {
    MessageSet::Meta(meta) => ...,
    MessageSet::Data(data) => ...,
    MessageSet::MetaData(meta, data) => ...
}
```