### PR TITLE
fix: fix macos compile error

### DIFF
--- a/taos-sys/build.rs
+++ b/taos-sys/build.rs
@@ -54,7 +54,7 @@ fn taos_version() -> String {
         "taos.dll"
     } else if cfg!(target_os = "linux") {
         "libtaos.so"
-    } else if cfg!(target_os = "darwin") {
+    } else if cfg!(target_os = "macos") {
         "libtaos.dylib"
     } else {
         unreachable!("the current os is not supported");


### PR DESCRIPTION
rust reference target_os example values is : https://doc.rust-lang.org/reference/conditional-compilation.html#target_os

associated issue #135