### PR TITLE
fix(sys): parse version with 5-fragments like 3.0.3.0.1

### DIFF
--- a/taos-sys/build.rs
+++ b/taos-sys/build.rs
@@ -123,7 +123,7 @@ impl Version {
     fn parse(version: &str) -> Result<Self, Box<dyn std::error::Error>> {
         let version_items: Vec<_> = version.split('.').collect();
         let items = version_items.len();
-        if items == 0 || items > 4 {
+        if items == 0 {
             Err("parse version error: {version}")?
         }
 


### PR DESCRIPTION
Close [TD-23165](https://jira.taosdata.com:18080/browse/TD-23165)