### PR TITLE
Fix an error by conditional compilation as well as some refactoring

### DIFF
--- a/taos-macros/Cargo.toml
+++ b/taos-macros/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 keywords = ["taos", "TDengine", "proc-macro"]
 license = "MIT OR Apache-2.0"
 description = "TDengine connector internal macros"
-private = true
 documentation = "https://taosdata.com"
 homepage = "https://taosdata.com"
 repository = "https://github.com/taosdata/taos-connector-rust"

--- a/taos-optin/src/tmq/raw.rs
+++ b/taos-optin/src/tmq/raw.rs
@@ -159,7 +159,6 @@ pub(super) mod tmq {
                 return vec![];
             }
 
-            let err_str = self.err_as_str(tmq_resp);
             if tmq_resp.is_err() {
                 return vec![];
             } 

--- a/taos/src/lib.rs
+++ b/taos/src/lib.rs
@@ -32,6 +32,8 @@ pub use taos_ws::*;
 
 #[cfg(all(any(feature = "native", feature = "optin"), not(feature = "ws")))]
 pub use crate::sys::*;
+#[cfg(all(any(feature = "native", feature = "optin"), not(feature = "ws")))]
+pub use sys::tmq::Offset;
 
 #[cfg(all(not(feature = "ws"), not(feature = "native"), not(feature = "optin")))]
 compile_error!("Either feature \"ws\" or \"native\"|"optin" or both must be enabled for this crate.");


### PR DESCRIPTION
Dears,

When use our connector with only `native` mode like:

```toml
taos = { version = "*", default-features = false, features = ["native"] }
```

The compiler will complain:

![image](https://github.com/taosdata/taos-connector-rust/assets/17194719/0ce0f727-a457-4e0d-ac2b-0d53c3ab1b8f)

I've checked the source code, the `Offset` will be imported by any backend (no matter `ws`, `native` or `optin`  it is):

```rust
#[cfg(any(feature = "ws", feature = "native", feature = "optin"))]
pub mod sync {
    pub use taos_query::prelude::sync::*;

    pub use super::Stmt;
    pub use super::{Consumer, MessageSet, Offset, TmqBuilder};
    pub use super::{Taos, TaosBuilder};
}
```

However, we only declared that these often used structs/enums come from `tmq` **in case of `ws` is enabled and one of the `native` or `optin` is enabled**.

```rust
#[cfg(all(feature = "ws", any(feature = "native", feature = "optin")))]
pub use tmq::{Consumer, Data, MessageSet, Meta, Offset, TmqBuilder};
```

Most of them could be solved by other module path in the crate root, except `Offset`, and I'm not sure if this is the expected behavior for `native` mode. But now, we have to labelled that `Offset` is from `taos_sys::tmq` explicitly.

It seems https://github.com/taosdata/taos-connector-rust/issues/185 could be solved here.

The PR also contains some refactoring works.