### PR TITLE
ref(ws): refactor with tokio-websockets crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,4 +28,4 @@ repository = "https://github.com/taosdata/taos-connector-rust.git"
 rust-version = "1.65"
 
 [patch.crates-io]
-tokio-websockets = { git = "https://github.com/Gelbpunkt/tokio-websockets.git" }
+tokio-websockets = { git = "https://github.com/zitsen/tokio-websockets.git" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,6 @@ license = "MIT OR Apache-2.0"
 readme = "./README.md"
 repository = "https://github.com/taosdata/taos-connector-rust.git"
 rust-version = "1.65"
+
+[patch.crates-io]
+tokio-websockets = { git = "https://github.com/Gelbpunkt/tokio-websockets.git" }

--- a/taos-ws/Cargo.toml
+++ b/taos-ws/Cargo.toml
@@ -29,11 +29,25 @@ serde_repr = "0.1.8"
 serde_with = "3.0.0"
 taos-query = { path = "../taos-query", version = "0.9.4" }
 thiserror = "1"
-tokio = { version = "1", features = ["sync", "rt-multi-thread", "macros", "io-util", "time"] }
+tokio = { version = "1", features = [
+	"sync",
+	"rt-multi-thread",
+	"macros",
+	"io-util",
+	"time",
+] }
 tokio-tungstenite = { version = "0.18.0" }
+
+tokio-websockets = { version = "*", default-features = false, features = [
+	"client",
+	"getrandom",
+	"simd",
+	"rustls-native-roots",
+] }
 
 [dev-dependencies]
 pretty_env_logger = "0.4.0"
+criterion = { version = "0.3", features = ["stable"] }
 
 [package.metadata.docs.rs]
 features = ["rustls"]

--- a/taos-ws/src/consumer/mod.rs
+++ b/taos-ws/src/consumer/mod.rs
@@ -65,7 +65,7 @@ impl WsTmqSender {
         self.queries.insert(req_id, tx);
 
         self.sender
-            .send_timeout(msg.to_msg(), send_timeout)
+            .send_timeout(msg.to_tungstenite_msg(), send_timeout)
             .await
             .map_err(WsTmqError::from)?;
 

--- a/taos-ws/src/lib.rs
+++ b/taos-ws/src/lib.rs
@@ -6,6 +6,8 @@ use once_cell::sync::OnceCell;
 use taos_query::prelude::Code;
 use taos_query::{DsnError, IntoDsn, RawResult};
 
+mod ws;
+
 pub mod stmt;
 pub use stmt::Stmt;
 

--- a/taos-ws/src/query/asyn.rs
+++ b/taos-ws/src/query/asyn.rs
@@ -1166,11 +1166,11 @@ async fn test_client_cloud() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 async fn ws_show_databases() -> anyhow::Result<()> {
     std::env::set_var("RUST_LOG", "debug");
     use futures::TryStreamExt;
-    pretty_env_logger::init_timed();
+    let _ = pretty_env_logger::try_init_timed();
     let dsn = std::env::var("TDENGINE_ClOUD_DSN").unwrap_or("http://localhost:6041".to_string());
     let client = WsTaos::from_dsn(dsn).await?;
     let mut rs = client.query("show databases").await?;
@@ -1183,7 +1183,7 @@ async fn ws_show_databases() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[tokio::test()]
+#[tokio::test]
 async fn ws_write_raw_block() -> anyhow::Result<()> {
     let mut raw = RawBlock::parse_from_raw_block_v2(
         &[0, 0, 0, 0, 0, 0, 0, 0, 2][..],

--- a/taos-ws/src/query/infra.rs
+++ b/taos-ws/src/query/infra.rs
@@ -203,8 +203,11 @@ fn test_serde_recv_data() {
 
 pub(crate) trait ToMessage: Serialize {
     // #[cfg(feature = "async")]
-    fn to_msg(&self) -> tokio_tungstenite::tungstenite::Message {
-        tokio_tungstenite::tungstenite::Message::Text(serde_json::to_string(self).unwrap())
+    fn to_tungstenite_msg(&self) -> tokio_tungstenite::tungstenite::protocol::Message {
+        tokio_tungstenite::tungstenite::protocol::Message::text(serde_json::to_string(self).unwrap())
+    }
+    fn to_msg(&self) -> tokio_websockets::Message {
+        tokio_websockets::Message::text(serde_json::to_string(self).unwrap())
     }
 }
 

--- a/taos-ws/src/query/mod.rs
+++ b/taos-ws/src/query/mod.rs
@@ -140,8 +140,8 @@ mod tests {
 
     #[test]
     fn ws_sync_json() -> anyhow::Result<()> {
-        std::env::set_var("RUST_LOG", "debug");
-        // pretty_env_logger::init();
+        std::env::set_var("RUST_LOG", "trace");
+        pretty_env_logger::try_init();
         use taos_query::prelude::sync::*;
         let client = TaosBuilder::from_dsn("taosws://localhost:6041/")?.build()?;
         let db = "ws_sync_json";
@@ -381,7 +381,7 @@ mod tests {
 
     #[cfg(feature = "async")]
     // !Websocket tests should always use `multi_thread`
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test()]
     async fn test_client() -> anyhow::Result<()> {
         std::env::set_var("RUST_LOG", "debug");
         // pretty_env_logger::init();

--- a/taos-ws/src/stmt/mod.rs
+++ b/taos-ws/src/stmt/mod.rs
@@ -725,14 +725,14 @@ mod tests {
         dbg!(&dsn);
 
         let taos = TaosBuilder::from_dsn("taos://localhost:6041")?.build()?;
-        taos.exec("drop database if exists stmt_sj").await?;
-        taos.exec("create database stmt_sj").await?;
-        taos.exec("create table stmt_sj.stb (ts timestamp, v int) tags(tj json)")
+        taos.exec("drop database if exists ws_stmt_sj1").await?;
+        taos.exec("create database ws_stmt_sj1").await?;
+        taos.exec("create table ws_stmt_sj1.stb (ts timestamp, v int) tags(tj json)")
             .await?;
 
         std::env::set_var("RUST_LOG", "debug");
         // pretty_env_logger::init();
-        let mut client = Stmt::from_dsn("taos+ws://localhost:6041/stmt_sj").await?;
+        let mut client = Stmt::from_dsn("taos+ws://localhost:6041/ws_stmt_sj1").await?;
         let stmt = client
             .s_stmt("insert into ? using stb tags(?) values(?, ?)")
             .await?;
@@ -754,7 +754,7 @@ mod tests {
 
         assert_eq!(res, 2);
         let row: (String, i32, std::collections::HashMap<String, String>) =
-            taos.query_one("select * from stmt_sj.stb").await?.unwrap();
+            taos.query_one("select * from ws_stmt_sj1.stb").await?.unwrap();
         dbg!(row);
 
         let tag_fields = stmt.stmt_get_tag_fields().await?;
@@ -765,7 +765,7 @@ mod tests {
 
         log::debug!("col fields: {:?}", col_fields);
 
-        taos.exec("drop database stmt_sj").await?;
+        taos.exec("drop database ws_stmt_sj1").await?;
         Ok(())
     }
 

--- a/taos-ws/src/ws/mod.rs
+++ b/taos-ws/src/ws/mod.rs
@@ -1,0 +1,111 @@
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use crate::query::infra::WsResArgs;
+    use crate::query::WsConnReq;
+
+    use super::*;
+    use futures::SinkExt;
+    use futures::StreamExt;
+    use tokio_websockets::{ClientBuilder, Message};
+
+    #[tokio::test]
+    async fn test_ws() {
+        let uri = "ws://127.0.0.1:6041/rest/ws".try_into().unwrap();
+        let (client, resp) = ClientBuilder::from_uri(uri).connect().await.unwrap();
+        dbg!(resp);
+
+        let (mut source, mut sink) = client.split();
+        // crate::query::infra:
+        let version = crate::query::infra::WsSend::Version;
+
+        source
+            .send(Message::text(serde_json::to_string(&version).unwrap()))
+            .await
+            .unwrap();
+
+        let conn = crate::query::infra::WsSend::Conn {
+            req_id: 0,
+            req: WsConnReq::new("root", "taosdata"),
+        };
+        source
+            .send(Message::text(serde_json::to_string(&version).unwrap()))
+            .await
+            .unwrap();
+        source
+            .send(Message::text(serde_json::to_string(&conn).unwrap()))
+            .await
+            .unwrap();
+
+        let query = crate::query::infra::WsSend::Query {
+            req_id: 1,
+            sql: "show databases".into(),
+        };
+        source
+            .send(Message::text(serde_json::to_string(&query).unwrap()))
+            .await
+            .unwrap();
+
+        let query = crate::query::infra::WsSend::Query {
+            req_id: 2,
+            sql: "select 1".into(),
+        };
+        source
+            .send(Message::text(serde_json::to_string(&query).unwrap()))
+            .await
+            .unwrap();
+
+        let query = crate::query::infra::WsSend::Fetch(WsResArgs { req_id: 1, id: 1 });
+        source
+            .send(Message::text(serde_json::to_string(&query).unwrap()))
+            .await
+            .unwrap();
+        let query = crate::query::infra::WsSend::Fetch(WsResArgs { req_id: 1, id: 2 });
+        source
+            .send(Message::text(serde_json::to_string(&query).unwrap()))
+            .await
+            .unwrap();
+
+        let (sender, receiver) = tokio::sync::mpsc::channel(1024);
+
+        let send_handle = tokio::spawn(async move {
+            let mut interval = tokio::time::interval(Duration::from_millis(100));
+            let mut receiver = receiver;
+            loop {
+                let msg = tokio::select! {
+                    _ = interval.tick() => {
+                        Message::ping("data")
+                    }
+                    res = receiver.recv() => {
+                        if let Some(res) = res {
+                            res
+                        } else {
+                            break;
+                        }
+                    }
+                };
+                let a = source.send(msg).await;
+                dbg!(a);
+            }
+            println!("finished");
+        });
+        let handle = tokio::spawn(async move {
+            while let Some(Ok(msg)) = sink.next().await {
+                if let Some(text) = msg.as_text() {
+                    let resp: crate::query::infra::WsRecv = serde_json::from_str(text).unwrap();
+                    dbg!(resp.data);
+                    // assert_eq!(text, "Hello world!");
+                    // We got one message, just stop now
+                    // source.close().await.unwrap();
+                }
+            }
+        });
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        sender.send(Message::close(None, "Closed by rust connector"));
+
+        // let abort_handle = handle.abort_handle();
+        // abort_handle.abort();
+        // tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+}

--- a/taos-ws/src/ws/mod.rs
+++ b/taos-ws/src/ws/mod.rs
@@ -5,7 +5,6 @@ mod tests {
     use crate::query::infra::WsResArgs;
     use crate::query::WsConnReq;
 
-    use super::*;
     use futures::SinkExt;
     use futures::StreamExt;
     use tokio_websockets::{ClientBuilder, Message};
@@ -69,7 +68,7 @@ mod tests {
 
         let (sender, receiver) = tokio::sync::mpsc::channel(1024);
 
-        let send_handle = tokio::spawn(async move {
+        let _ = tokio::spawn(async move {
             let mut interval = tokio::time::interval(Duration::from_millis(100));
             let mut receiver = receiver;
             loop {


### PR DESCRIPTION
To use tokio::test without multi_thread flavor.