### PR TITLE
fix(taos-sys): fix error `SIGSEGV: invalid memory reference` caused by pointer to wrong heap

### DIFF
--- a/taos-sys/src/stmt/mod.rs
+++ b/taos-sys/src/stmt/mod.rs
@@ -9,7 +9,7 @@ use taos_query::{common::Ty, stmt::Bindable, Queryable, RawResult};
 
 use crate::types::*;
 
-mod bind;
+pub(super) mod bind;
 mod multi;
 
 #[derive(Debug)]


### PR DESCRIPTION
To resolve the issue reported in https://github.com/taosdata/taos-connector-rust/issues/257, I ran the unit test `test_taos_null` under the LLDB debugger:

![image](https://github.com/taosdata/taos-connector-rust/assets/17194719/8c26f3c5-388d-4c78-9ce3-be925da20d34)

Based on the information obtained from the Call Stack panel, it is evident that the error occurred in the C function `qBindStmtTagsValue`. To get the exact nature of the issue:

![image](https://github.com/taosdata/taos-connector-rust/assets/17194719/254f347d-a0ee-42f2-9dab-21c83332a04e)

The directive signifies that a value of `int32` data type (the `movl` is short for "move long") has been transferred from the RSI register to the target.

To gain a better understanding of the operations performed in the `qBindStmtTagsValue` function, one should carefully analyze the code from top to bottom. There is a short-circuit logic in place, which entails that any `null` values of the tag should be skipped (no operations should be performed on them):

```c
for (int c = 0; c < tags->numOfBound; ++c) {
    if (bind[c].is_null && bind[c].is_null[0]) {
      continue;
    }
// Other operations...
}
```

If the condition in the `if` statement evaluates to `true`, no variables of type `int32` will be moved.

Here, the iteration involves looping through an array in C that represents a collection of the Rust structure `TaosMultiBind`. Each `bind[c]` within the array corresponds to a tag value. It is worth noting that the definition of `TaosMultiBind` is as follows:

```rust
#[repr(C)]
#[derive(Debug, Clone)]
pub struct TaosMultiBind {
    pub buffer_type: c_int,
    pub buffer: *const c_void,
    pub buffer_length: usize,
    pub length: *const i32,
    pub is_null: *const c_char,
    pub num: c_int,
}
```

The `c_char` type is defined in FFI and must be either `u8` or `i8`. In C, since `0` is always cast to `false`, if we want to ensure that the `null` value of the tag is correctly skipped in the C code listing mentioned earlier, the `is_null` field must be assigned a value that is not equal to zero. The original code mistakenly uses a null mutable raw pointer, resulting in `bind[c].is_null` being evaluated as `false`. It is worth noting that using a `Box` with only `0i8` or `0u8` on the heap will also yield a false result, so I finally use something equivalent to `Box::new(1)` and it works.