### PR TITLE
fix(libtaosws): use ring crypto provider by default

### DIFF
--- a/taos-ws-sys/Cargo.toml
+++ b/taos-ws-sys/Cargo.toml
@@ -28,11 +28,15 @@ cbindgen = "0.27.0"
 pretty_env_logger = "0.5.0"
 
 [features]
-rustls-ring-crypto-provider = ["rustls", "taos-ws/rustls-ring-crypto-provider"]
-default = ["rustls", "rustls-aws-lc-crypto-provider"]
+default = ["rustls", "rustls-ring-crypto-provider"]
+
 native-tls-vendored = ["taos-ws/native-tls-vendored"]
 native-tls = ["taos-ws/native-tls"]
 rustls = ["taos-ws/rustls"]
+rustls-ring-crypto-provider = [
+    "rustls",
+    "taos-ws/rustls-ring-crypto-provider",
+]
 rustls-aws-lc-crypto-provider = [
     "rustls",
     "taos-ws/rustls-aws-lc-crypto-provider",


### PR DESCRIPTION
To fix win32 compile errors with aws-lc-sys