### PR TITLE
fix: fix the timestamp precision issue in the modeless write line protocol

### DIFF
--- a/taos-query/src/common/raw/mod.rs
+++ b/taos-query/src/common/raw/mod.rs
@@ -1254,7 +1254,7 @@ impl From<SchemalessPrecision> for String {
             SchemalessPrecision::Minutes => "m".to_string(),
             SchemalessPrecision::Seconds => "s".to_string(),
             SchemalessPrecision::Millisecond => "ms".to_string(),
-            SchemalessPrecision::Microsecond => "us".to_string(),
+            SchemalessPrecision::Microsecond => "u".to_string(),
             SchemalessPrecision::Nanosecond => "ns".to_string(),
             SchemalessPrecision::NonConfigured => String::new(),
         }

--- a/taos-ws-sys/src/ws/sml.rs
+++ b/taos-ws-sys/src/ws/sml.rs
@@ -694,6 +694,41 @@ mod tests {
     }
 
     #[test]
+    fn test_sml_insert_raw_line_micro_seconds() {
+        unsafe {
+            let taos = test_connect();
+            test_exec_many(
+                taos,
+                &[
+                    "drop database if exists test_1778486191",
+                    "create database test_1778486191 precision 'us'",
+                    "use test_1778486191",
+                ],
+            );
+
+            let data = "measurement,host=host1 field1=2i,field2=2.0 1741153642000000";
+            let data = data.as_bytes();
+            let len = data.len() as i32;
+            let lines = data.as_ptr() as *mut _;
+            let mut total_rows = 0;
+            let protocol = TSDB_SML_PROTOCOL_TYPE::TSDB_SML_LINE_PROTOCOL as i32;
+            let precision = TSDB_SML_TIMESTAMP_TYPE::TSDB_SML_TIMESTAMP_MICRO_SECONDS as i32;
+
+            let res =
+                taos_schemaless_insert_raw(taos, lines, len, &mut total_rows, protocol, precision);
+            assert!(!res.is_null());
+            assert_eq!(total_rows, 1);
+
+            let affected_rows = taos_affected_rows(res);
+            assert_eq!(affected_rows, 1);
+
+            taos_free_result(res);
+            test_exec(taos, "drop database test_1778486191");
+            taos_close(taos);
+        }
+    }
+
+    #[test]
     fn test_sml_insert() {
         unsafe {
             let taos = test_connect();


### PR DESCRIPTION
# Description

<!-- Please briefly describe the code changes in this pull request. -->

fix: fix the timestamp precision issue in the modeless write line protocol

# Issue(s)

- fix: https://project.feishu.cn/taosdata_td/defect/detail/6987326937

# Checklist

Please check the items in the checklist if applicable.

- [ ] Is the user manual updated?
- [x] Are the test cases passed and automated?
- [x] Is there no significant decrease in test coverage?
